### PR TITLE
Improve setuptools fallback handling without setuptools

### DIFF
--- a/sf3dmodels/_setuptools_shim.py
+++ b/sf3dmodels/_setuptools_shim.py
@@ -1,0 +1,95 @@
+"""Minimal ``setuptools`` shim exposed as ``astropy_helpers.setuptools_shim``.
+
+This module is imported by :mod:`setup.py` when ``setuptools`` is unavailable.
+It provides a very small subset of :func:`setuptools.setup`, delegating to
+``distutils.core.setup`` when available and silently discarding keyword
+arguments that are only recognised by ``setuptools``.  The module registers
+itself in :data:`sys.modules` so that it is accessible via the canonical
+``astropy_helpers.setuptools_shim`` import path expected by upstream tooling.
+"""
+
+from __future__ import absolute_import
+
+import re
+import sys
+import warnings
+
+try:  # pragma: no cover -- Python 3 already defines ModuleNotFoundError
+    ModuleNotFoundError  # type: ignore[name-defined]
+except NameError:  # pragma: no cover
+    ModuleNotFoundError = ImportError  # type: ignore[assignment]
+
+try:  # pragma: no cover -- ``distutils`` is available in supported runtimes
+    from distutils.core import setup as _DISTUTILS_SETUP
+except ImportError:  # pragma: no cover
+    _DISTUTILS_SETUP = None
+
+# Register the module under the ``astropy_helpers`` namespace so that callers
+# can simply ``import astropy_helpers.setuptools_shim``.
+module_name = "astropy_helpers.setuptools_shim"
+module_obj = sys.modules.get(__name__)
+if module_obj is None:  # pragma: no cover - defensive for importlib loaders
+    import types
+
+    module_obj = types.ModuleType(__name__)
+    module_obj.__dict__.update(globals())
+    sys.modules[__name__] = module_obj
+
+if module_name not in sys.modules:
+    sys.modules[module_name] = module_obj
+
+# Keywords understood by ``setuptools`` but rejected by ``distutils``.
+_IGNORED_KEYWORDS = {
+    "entry_points",
+    "extras_require",
+    "install_requires",
+    "include_package_data",
+    "python_requires",
+    "setup_requires",
+    "use_2to3",
+    "zip_safe",
+}
+
+_UNSUPPORTED_ARG_RE = re.compile(r"unexpected keyword argument '([^']+)'")
+
+
+def setup(*args, **kwargs):
+    """A very small subset of :func:`setuptools.setup`.
+
+    Parameters
+    ----------
+    *args, **kwargs
+        Arguments passed to ``setup``.  Unsupported keyword arguments are
+        quietly discarded so that ``distutils`` can continue without error.
+    """
+
+    if _DISTUTILS_SETUP is None:  # pragma: no cover
+        raise ModuleNotFoundError(
+            "setuptools is required to build this package and distutils is not "
+            "available"
+        )
+
+    # Remove known ``setuptools``-specific keywords before invoking distutils.
+    for key in list(kwargs):
+        if key in _IGNORED_KEYWORDS:
+            kwargs.pop(key, None)
+
+    while True:
+        try:
+            return _DISTUTILS_SETUP(*args, **kwargs)
+        except TypeError as exc:
+            match = _UNSUPPORTED_ARG_RE.search(str(exc))
+            if not match:
+                raise
+            unsupported_key = match.group(1)
+            removed = kwargs.pop(unsupported_key, None)
+            if removed is None:
+                raise
+            warnings.warn(
+                "Ignoring unsupported distutils keyword: {}".format(unsupported_key),
+                RuntimeWarning,
+                stacklevel=2,
+            )
+
+
+__all__ = ["setup"]

--- a/sf3dmodels/conftest.py
+++ b/sf3dmodels/conftest.py
@@ -1,19 +1,32 @@
 # This file is used to configure the behavior of pytest when using the Astropy
 # test infrastructure.
 
-from astropy.version import version as astropy_version
-if astropy_version < '3.0':
-    # With older versions of Astropy, we actually need to import the pytest
-    # plugins themselves in order to make them discoverable by pytest.
-    from astropy.tests.pytest_plugins import *
-else:
-    # As of Astropy 3.0, the pytest plugins provided by Astropy are
-    # automatically made available when Astropy is installed. This means it's
-    # not necessary to import them here, but we still need to import global
-    # variables that are used for configuration.
-    from astropy.tests.plugins.display import PYTEST_HEADER_MODULES, TESTED_VERSIONS
+import importlib
 
-from astropy.tests.helper import enable_deprecations_as_exceptions
+_ASTROPY_SPEC = importlib.util.find_spec("astropy")
+
+if _ASTROPY_SPEC is None:  # pragma: no cover - exercised in CI where astropy missing
+    astropy_version = "0"
+    PYTEST_HEADER_MODULES = {}
+    TESTED_VERSIONS = {}
+
+    def enable_deprecations_as_exceptions(*args, **kwargs):
+        """Shim used when Astropy is not installed."""
+
+else:
+    from astropy.version import version as astropy_version
+    if astropy_version < '3.0':
+        # With older versions of Astropy, we actually need to import the pytest
+        # plugins themselves in order to make them discoverable by pytest.
+        from astropy.tests.pytest_plugins import *  # noqa: F403,F401
+    else:
+        # As of Astropy 3.0, the pytest plugins provided by Astropy are
+        # automatically made available when Astropy is installed. This means it's
+        # not necessary to import them here, but we still need to import global
+        # variables that are used for configuration.
+        from astropy.tests.plugins.display import PYTEST_HEADER_MODULES, TESTED_VERSIONS
+
+    from astropy.tests.helper import enable_deprecations_as_exceptions
 
 ## Uncomment the following line to treat all DeprecationWarnings as
 ## exceptions. For Astropy v2.0 or later, there are 2 additional keywords,

--- a/sf3dmodels/tests/test_astropy_helpers_shim.py
+++ b/sf3dmodels/tests/test_astropy_helpers_shim.py
@@ -1,0 +1,127 @@
+from __future__ import absolute_import
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import builtins
+import types
+
+
+def _module_not_found_error():  # pragma: no cover - helper for Python 2 compat
+    try:
+        return ModuleNotFoundError  # type: ignore[name-defined]
+    except NameError:  # pragma: no cover
+        return ImportError
+
+
+def test_setup_py_uses_shim_when_setuptools_missing(monkeypatch):
+    from sf3dmodels import _setuptools_shim as shim
+
+    recorded = {}
+
+    def fake_setup(*args, **kwargs):
+        recorded["called"] = True
+        recorded["kwargs"] = kwargs
+
+    monkeypatch.setattr(shim, "setup", fake_setup)
+
+    for modname in [m for m in sys.modules if m.startswith("setuptools")]:
+        monkeypatch.delitem(sys.modules, modname, raising=False)
+
+    missing_exc = _module_not_found_error()
+    original_import = builtins.__import__
+
+    def blocked_import(name, *args, **kwargs):
+        if name.startswith("setuptools"):
+            raise missing_exc("No module named '{}'".format(name))
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", blocked_import, raising=False)
+    monkeypatch.setattr(sys, "argv", ["setup.py", "build"])
+
+    # Provide lightweight stand-ins for the pieces of astropy_helpers that
+    # setup.py expects to import so the module can be executed safely.
+    fake_astropy_helpers = types.ModuleType("astropy_helpers")
+    fake_astropy_helpers.__path__ = []
+    fake_setup_helpers = types.ModuleType("astropy_helpers.setup_helpers")
+    fake_git_helpers = types.ModuleType("astropy_helpers.git_helpers")
+    fake_version_helpers = types.ModuleType("astropy_helpers.version_helpers")
+    fake_ah_bootstrap = types.ModuleType("ah_bootstrap")
+    fake_distutils = types.ModuleType("distutils")
+    fake_distutils.__path__ = []
+    fake_distutils_core = types.ModuleType("distutils.core")
+    fake_distutils_version = types.ModuleType("distutils.version")
+
+    class _LooseVersion(object):
+        def __init__(self, version):
+            self.version = version
+
+        def __lt__(self, other):  # pragma: no cover - simple shim
+            return str(self.version) < str(getattr(other, "version", other))
+
+    fake_distutils_core.setup = lambda *a, **k: None
+    fake_distutils_version.LooseVersion = _LooseVersion
+    fake_distutils.core = fake_distutils_core
+    fake_distutils.version = fake_distutils_version
+
+    from collections import defaultdict
+
+    def _get_package_info():
+        return {
+            "package_data": defaultdict(list),
+            "packages": [],
+            "package_dir": {},
+            "ext_modules": [],
+        }
+
+    fake_setup_helpers.register_commands = lambda *a, **k: {}
+    fake_setup_helpers.get_debug_option = lambda *a, **k: False
+    fake_setup_helpers.get_package_info = _get_package_info
+    fake_git_helpers.get_git_devstr = lambda *a, **k: ""
+    fake_version_helpers.generate_version_py = lambda *a, **k: None
+
+    for name, module in {
+        "astropy_helpers": fake_astropy_helpers,
+        "astropy_helpers.setup_helpers": fake_setup_helpers,
+        "astropy_helpers.git_helpers": fake_git_helpers,
+        "astropy_helpers.version_helpers": fake_version_helpers,
+        "astropy_helpers.setuptools_shim": shim,
+        "ah_bootstrap": fake_ah_bootstrap,
+        "distutils": fake_distutils,
+        "distutils.core": fake_distutils_core,
+        "distutils.version": fake_distutils_version,
+    }.items():
+        if name in sys.modules:
+            monkeypatch.delitem(sys.modules, name, raising=False)
+        monkeypatch.setitem(sys.modules, name, module)
+
+    setup_path = Path(__file__).resolve().parents[2] / "setup.py"
+    module_name = "sf3dmodels_setup_for_test"
+    spec = importlib.util.spec_from_file_location(module_name, str(setup_path))
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)  # type: ignore[union-attr]
+    finally:
+        sys.modules.pop(module_name, None)
+
+    assert recorded.get("called", False), "Shim setup was not invoked"
+
+
+def test_shim_ignores_setuptools_only_keywords(monkeypatch):
+    from sf3dmodels import _setuptools_shim  # ensures alias registration
+    from astropy_helpers import setuptools_shim as shim
+
+    captured = {}
+
+    def fake_distutils_setup(*args, **kwargs):
+        captured["kwargs"] = kwargs
+        return "ok"
+
+    monkeypatch.setattr(shim, "_DISTUTILS_SETUP", fake_distutils_setup)
+
+    result = shim.setup(name="pkg", entry_points={"console_scripts": []})
+
+    assert result == "ok"
+    assert captured["kwargs"] == {"name": "pkg"}


### PR DESCRIPTION
## Summary
- load a local shim when setuptools cannot be imported so setup.py still runs
- provide a minimal setuptools shim that forwards to distutils while dropping unsupported keywords
- add regression tests that emulate environments without setuptools and exercise the shim
- allow pytest configuration to proceed when astropy is unavailable and guard the ah_bootstrap import when setuptools is missing

## Testing
- `pytest sf3dmodels/tests/test_astropy_helpers_shim.py`


------
https://chatgpt.com/codex/tasks/task_e_68defec3b6f8832b9cf1323d7be30925